### PR TITLE
Fix/0.1.1 improves test

### DIFF
--- a/src/needle/needle.go
+++ b/src/needle/needle.go
@@ -47,7 +47,7 @@ func Build() {
 	v := depVisiter{Hist: col.NewStack[reflect.Type](nil)}
 	roids.servicesGraph.BFSWalk(&v)
 
-	for v.Hist.GetSize()-1 > 0 {
+	for v.Hist.GetSize() > 0 {
 		serviceType := *v.Hist.Pop()
 		service := roids.services[serviceType]
 		if service.isLeaf && !service.created {

--- a/src/needle/needle.go
+++ b/src/needle/needle.go
@@ -94,9 +94,6 @@ Private stuff
 // Application wide instance of the dependency container.
 var instance *needleContainer
 
-// Graph of dependent services.
-// var servicesGraph = dag.NewDAG()
-
 // Atomic boolean to ensure that the container is only created once.
 var once sync.Once
 

--- a/src/needle/needle.go
+++ b/src/needle/needle.go
@@ -28,27 +28,28 @@ func GetRoids() *needleContainer {
 
 // Method to traverse the entire dependency graph
 func (pv *depVisiter) Visit(v dag.Vertexer) {
+	roids := GetRoids()
 	id, value := v.Vertex()
 	sType := value.(reflect.Type)
 	pv.Hist.Push(sType)
-	isLeaf, err := servicesGraph.IsLeaf(id)
+	isLeaf, err := roids.servicesGraph.IsLeaf(id)
 	if err != nil {
 		println("Node with id not found")
 	}
-	services[sType].isLeaf = isLeaf
+	roids.services[sType].isLeaf = isLeaf
 }
 
 // Build the dependency injection IoC container
 func Build() {
 	// Instantiate/Get IoC Container
-	_ = GetRoids()
+	roids := GetRoids()
 
 	v := depVisiter{Hist: col.NewStack[reflect.Type](nil)}
-	servicesGraph.BFSWalk(&v)
+	roids.servicesGraph.BFSWalk(&v)
 
 	for v.Hist.GetSize()-1 > 0 {
 		serviceType := *v.Hist.Pop()
-		service := services[serviceType]
+		service := roids.services[serviceType]
 		if service.isLeaf && !service.created {
 			createLeafDep(serviceType)
 		} else if !service.isLeaf && !service.created {
@@ -72,7 +73,18 @@ func Build() {
 
 // Prints all dependencies in the container
 func PrintDependencyGraph() {
-	fmt.Println(servicesGraph.String())
+	roids := GetRoids()
+	fmt.Println(roids.servicesGraph.String())
+}
+
+// Clears the container of all services
+// SUPER UNSAFE. Only used during testing. Dont use while running an application.
+func UNSAFE_Clear() {
+	roids := GetRoids()
+	for t := range roids.services {
+		delete(roids.services, t)
+	}
+	roids.servicesGraph = dag.NewDAG()
 }
 
 /**
@@ -82,14 +94,11 @@ Private stuff
 // Application wide instance of the dependency container.
 var instance *needleContainer
 
-// Map of all the services in the container.
-var services = make(map[reflect.Type]*Service)
+// Graph of dependent services.
+// var servicesGraph = dag.NewDAG()
 
 // Atomic boolean to ensure that the container is only created once.
 var once sync.Once
-
-// Graph of dependent services.
-var servicesGraph = dag.NewDAG()
 
 // Dependency visitor. It keeps track of the nodes visited into a stack,
 // so that we can instantiate leaf deps by popping them out.
@@ -100,6 +109,7 @@ type depVisiter struct {
 
 // Get all deps before using injector.
 func getArgsForFunction(service *Service) []reflect.Value {
+	roids := GetRoids()
 	injected := service.Injector
 	injectedVal := reflect.ValueOf(injected)
 	injectedType := injectedVal.Type()
@@ -109,7 +119,7 @@ func getArgsForFunction(service *Service) []reflect.Value {
 	// Get the type of each argument
 	for i := 0; i < injectedType.NumIn(); i++ {
 		serviceType := injectedType.In(i)
-		instanceVal := reflect.ValueOf(*(services[serviceType].instance))
+		instanceVal := reflect.ValueOf(*(roids.services[serviceType].instance))
 		argValues[i] = instanceVal
 	}
 	return argValues
@@ -119,15 +129,16 @@ func getArgsForFunction(service *Service) []reflect.Value {
 // These services should not have parameters in there injector functions.
 // Meaning they can be created easily without problem.
 func createLeafDep(sType reflect.Type) {
-	injected := services[sType].Injector
+	roids := GetRoids()
+	injected := roids.services[sType].Injector
 	injectedVal := reflect.ValueOf(injected)
 	if injectedVal.Kind() == reflect.Func {
 		// If the instance is a function, call it
 		results := injectedVal.Call(nil)
 		// Handle results if necessary
 		instance := results[0].Interface()
-		services[sType].instance = &instance
-		services[sType].created = true
+		roids.services[sType].instance = &instance
+		roids.services[sType].created = true
 
 	} else {
 		fmt.Println("Instance is not a function")
@@ -137,14 +148,16 @@ func createLeafDep(sType reflect.Type) {
 // needleContainer is a struct that holds all the dependencies for the application.
 // It is recommended to use the `GetNeedle` function to get the global instance.
 type needleContainer struct {
-	services map[reflect.Type]*Service
-	context  context.Context
+	services      map[reflect.Type]*Service
+	servicesGraph *dag.DAG
+	context       context.Context
 }
 
 // Creates a new instance of the dependency container.
 // This function should not be used directly. Use `GetNeedle` instead.
 func newNeedle() *needleContainer {
 	return &needleContainer{
-		services: services,
+		services:      make(map[reflect.Type]*Service),
+		servicesGraph: dag.NewDAG(),
 	}
 }

--- a/src/needle/needle_test.go
+++ b/src/needle/needle_test.go
@@ -1,13 +1,165 @@
-package needle
+package needle_test
 
 import (
 	"testing"
+
+	"github.com/ShounakA/roids/needle"
 )
 
+type (
+	testInterface interface {
+		DoSomethingBob() string
+	}
+
+	dependedService interface {
+		PlanSomething() string
+	}
+
+	iCycleService interface {
+		WontWorkBeforeTo() string
+	}
+
+	ibCycleService interface {
+		WontWorkBeforeMain()
+	}
+
+	iToCycleService interface {
+		WontWorkBeforeB() string
+	}
+)
+
+type (
+	testObject struct {
+		something      string
+		dependedObject dependedService
+	}
+
+	dependedObject struct {
+		plan string
+	}
+
+	cycleService struct {
+		cycle iToCycleService
+	}
+
+	toCycleService struct {
+		bCycle ibCycleService
+	}
+
+	bCycleService struct {
+		ogCycle iCycleService
+	}
+)
+
+func newTestObject(service dependedService) *testObject {
+	return &testObject{
+		something:      "Testing add",
+		dependedObject: service,
+	}
+}
+
+func newDependedObject() *dependedObject {
+	return &dependedObject{
+		plan: "Drive",
+	}
+}
+
+func newCycle(toCycle iToCycleService) *cycleService {
+	return &cycleService{
+		cycle: toCycle,
+	}
+}
+
+func newToCycle(bCycle ibCycleService) *toCycleService {
+	return &toCycleService{
+		bCycle: bCycle,
+	}
+}
+
+func newBCycle(mainCycle iCycleService) *bCycleService {
+	return &bCycleService{
+		ogCycle: mainCycle,
+	}
+}
+
+func (obj *testObject) DoSomethingBob() string {
+	obj.dependedObject.PlanSomething()
+	println(obj.something)
+	return obj.something
+}
+
+func (obj *dependedObject) PlanSomething() string {
+	println(obj.plan)
+	return obj.plan
+}
+
+func (obj *cycleService) WontWorkBeforeTo() string {
+	return "to"
+}
+
+func (obj *toCycleService) WontWorkBeforeB() string {
+	return "b"
+}
+
+func (obj *bCycleService) WontWorkBeforeMain() string {
+	return "main"
+}
+
 func TestGetNeedle(t *testing.T) {
-	roids := GetRoids()
-	secondRoids := GetRoids()
+	roids := needle.GetRoids()
+	secondRoids := needle.GetRoids()
 	if roids != secondRoids {
 		t.Error("Both roids should be the same instance.")
 	}
+}
+
+func TestAddService(t *testing.T) {
+
+	_ = needle.GetRoids()
+
+	err := needle.AddService(new(testInterface), newTestObject)
+	if err != nil {
+		t.Error("Should be able to add simple dependencies.")
+	}
+	err = needle.AddService(new(dependedService), newDependedObject)
+	if err != nil {
+		t.Error("Should be able to add simple dependencies.")
+	}
+
+	needle.UNSAFE_Clear()
+}
+
+func TestAddService_IncorrectOrder(t *testing.T) {
+
+	_ = needle.GetRoids()
+
+	err := needle.AddService(new(dependedService), newDependedObject)
+	if err != nil {
+		t.Error("Should be able to add simple dependency", err.Error())
+	}
+	err = needle.AddService(new(testInterface), newTestObject)
+	if err != nil {
+		t.Error("Added dependency with first define the service.", err.Error())
+	}
+	needle.UNSAFE_Clear()
+
+}
+
+func TestAddService_CircularDependency(t *testing.T) {
+	_ = needle.GetRoids()
+
+	err := needle.AddService(new(iCycleService), newCycle)
+	if err != nil {
+		t.Error("Should be able to add simple out of order dependencies.", err.Error())
+	}
+	err = needle.AddService(new(iToCycleService), newToCycle)
+	if err != nil {
+		t.Error("Should be able to add simple out of order dependencies.", err.Error())
+	}
+	err = needle.AddService(new(ibCycleService), newBCycle)
+	if err == nil {
+		t.Error("Should catch circular dependency here!!")
+	}
+
+	needle.UNSAFE_Clear()
 }

--- a/src/needle/service.go
+++ b/src/needle/service.go
@@ -7,7 +7,11 @@
 // There is only ever one container and it can be used globally to access all the dependencies.
 package needle
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/heimdalr/dag"
+)
 
 // Struct representing an injectable service. (aka Provider, Assembler, Service, or Injector)
 type Service struct {
@@ -21,30 +25,42 @@ type Service struct {
 
 // Adds a service to the container.
 // Uses the specification (interface or struct) to inject an implmentation into the IoC container
-func AddService[T interface{}](spec T, impl any) {
+func AddService[T interface{}](spec T, impl any) error {
+
+	// spec must be interface
+	// imple must be func
+
 	// Get IoC Container
 	container := GetRoids()
 	specType := reflect.TypeOf(spec).Elem()
+	ftype := reflect.TypeOf(impl)
 
 	// Add vertex for the service being added
-	thisV, _ := servicesGraph.AddVertex(specType)
+	thisV, err := container.servicesGraph.AddVertex(specType)
+	if err != nil {
+		// It means we added a vertex for this service before via a constructor.
+		// SO we must lookup the id based on the service type.
+		lookup := &reverseLookupVisiter{searchType: specType}
+		container.servicesGraph.BFSWalk(lookup)
+		thisV = lookup.vertexId
+	}
 	container.services[specType] = &Service{Id: thisV, Injector: impl}
 
-	ftype := reflect.TypeOf(impl)
 	// Get all dependencies in injector
 	for i := 0; i < ftype.NumIn(); i++ {
 		field := ftype.In(i)
 		// Add vertex for dependency
-		depV, err := servicesGraph.AddVertex(field)
+		depV, err := container.servicesGraph.AddVertex(field)
 		if err != nil {
 			depV = container.services[field].Id
 		}
 		// Add edge
-		err = servicesGraph.AddEdge(thisV, depV)
+		err = container.servicesGraph.AddEdge(thisV, depV)
 		if err != nil {
-			println(err.Error())
+			return err
 		}
 	}
+	return nil
 }
 
 // Gets an implementation of a service based on an specification from the container.
@@ -52,4 +68,20 @@ func Inject[T interface{}]() T {
 	c := GetRoids()
 	implType := reflect.TypeOf(new(T)).Elem()
 	return (*(c.services[implType].instance)).(T)
+}
+
+type reverseLookupVisiter struct {
+	vertexId   string
+	searchType reflect.Type
+	updateType reflect.Type
+}
+
+// Function to lookup vertexId based on spec
+func (pv *reverseLookupVisiter) Visit(v dag.Vertexer) {
+	id, value := v.Vertex()
+	sType := value.(reflect.Type)
+	if sType == pv.searchType {
+		pv.vertexId = id
+		return
+	}
 }

--- a/src/version.yaml
+++ b/src/version.yaml
@@ -1,1 +1,1 @@
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
- moves the global services and serviceGraph types into the needContainer, instead of tied to the package.
- adds tests for AddService for simple deps, as well as circular dependency.