### PR TITLE
fix: injecting transient deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - UNRELEASED
+
+### Fixed
+- Fixes instantiation order when creating transient dependencies.
+
+## [0.2.0] - 2024-01-22
+
+### Added
+- Adds dependency lifecycles: static and transient.
+
+## [0.1.1] - 2024-01-19
+
+### Changed
+- Improves unit tests
+
+### Fixed
+- `Inject` not working 
+
+## [0.1.0] - 2024-01-19
+
+### Added
+
+- Adds roids dependency injection container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - UNRELEASED
+## [0.2.1] - 2024-01-27
 
 ### Fixed
 - Fixes instantiation order when creating transient dependencies.

--- a/service_graph.go
+++ b/service_graph.go
@@ -8,6 +8,7 @@
 package roids
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -80,6 +81,9 @@ func (graph *serviceGraph) GetVertex(id string) (*Service, error) {
 }
 
 func (graph *serviceGraph) AddVertex(service *Service) error {
+	if service == nil {
+		return errors.New("Cannot add nil service")
+	}
 	id, err := graph.dag.AddVertex(service)
 	service.Id = id
 	if err != nil {
@@ -89,6 +93,9 @@ func (graph *serviceGraph) AddVertex(service *Service) error {
 }
 
 func (graph *serviceGraph) AddEdge(srcService *Service, depService *Service) error {
+	if srcService == nil || depService == nil {
+		return errors.New("Cannot add edge to or from nil")
+	}
 	err := graph.dag.AddEdge(srcService.Id, depService.Id)
 	if err != nil {
 		switch e := err.(type) {

--- a/service_graph_test.go
+++ b/service_graph_test.go
@@ -1,0 +1,247 @@
+package roids
+
+import (
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/heimdalr/dag"
+)
+
+var mockDag *dag.DAG
+var graph *serviceGraph
+
+func setupTest(tb testing.TB) func(tb testing.TB) {
+	log.Println("setup test")
+	mockDag = dag.NewDAG()
+	graph = newServiceGraph(mockDag)
+
+	return func(tb testing.TB) {
+		graph = nil
+		mockDag = nil
+		log.Println("teardown test")
+	}
+}
+func TestInstantiatingServiceGraph(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+
+	if graph.dag != mockDag {
+		t.Errorf("Did no instantiate service graph correctly.")
+	}
+}
+
+func TestAddVertex(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedOrder := 1
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+	actualOrder := graph.dag.GetOrder()
+	if expectedOrder != actualOrder {
+		t.Errorf("Did not add the vertex correctly.")
+	}
+
+	if myService.Id == "" {
+		t.Errorf("Did no mutate the services ID field.")
+	}
+}
+
+func TestAddVertex_InvalidParameters(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedOrder := 0
+
+	err := graph.AddVertex(nil)
+	if err == nil {
+		t.Errorf("Should not allow nil")
+	}
+
+	if graph.dag.GetOrder() != expectedOrder {
+		t.Errorf("Should not add nil to service graph")
+	}
+}
+
+func TestAddVertex_DuplicateService(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedOrder := 1
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+	err = graph.AddVertex(myService)
+	if err == nil {
+		t.Errorf("Should no add duplicate vertex")
+	}
+	err = graph.AddVertex(&Service{SpecType: testSpec})
+	if err == nil {
+		t.Errorf("Should no add duplicate vertex")
+	}
+	actualOrder := graph.dag.GetOrder()
+	if expectedOrder != actualOrder {
+		t.Errorf("Did not add the vertex correctly.")
+	}
+}
+
+func TestAddEdge(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedSize := 1
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	testSpec2 := reflect.TypeOf(int64(5))
+	myService2 := &Service{SpecType: testSpec2}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+	err = graph.AddVertex(myService2)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+
+	err = graph.AddEdge(myService, myService2)
+	if err != nil {
+		t.Errorf("Should add edge! %s", err.Error())
+	}
+
+	if graph.dag.GetSize() != expectedSize {
+		t.Errorf("Should have added edge to dag")
+	}
+}
+
+func TestAddEdge_InvalidParameters(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	testSpec := reflect.TypeOf(4)
+	myService := &Service{SpecType: testSpec}
+
+	err := graph.AddEdge(nil, myService)
+	if err == nil {
+		t.Errorf("Should not allow nil services!")
+	}
+
+	err = graph.AddEdge(myService, nil)
+	if err == nil {
+		t.Errorf("Should not allow nil services!")
+	}
+
+}
+
+func TestAddEdge_CircularDeps(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedSize := 1
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	testSpec2 := reflect.TypeOf(int64(5))
+	myService2 := &Service{SpecType: testSpec2}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+	err = graph.AddVertex(myService2)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+
+	err = graph.AddEdge(myService, myService2)
+	if err != nil {
+		t.Errorf("Should add edge! %s", err.Error())
+	}
+
+	err = graph.AddEdge(myService2, myService)
+	if err == nil {
+		t.Errorf("Should not create circular dependency")
+	}
+	if nerr, ok := err.(*CircularDependencyError); !ok {
+		t.Error("Unexpected error returned.", nerr.Error())
+	}
+
+	if graph.dag.GetSize() != expectedSize {
+		t.Errorf("Should have added edge to dag")
+	}
+}
+
+func TestAddEdge_DuplicateEdge(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+	expectedSize := 1
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	testSpec2 := reflect.TypeOf(int64(5))
+	myService2 := &Service{SpecType: testSpec2}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+	err = graph.AddVertex(myService2)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+
+	err = graph.AddEdge(myService, myService2)
+	if err != nil {
+		t.Errorf("Should add edge! %s", err.Error())
+	}
+
+	err = graph.AddEdge(myService, myService2)
+	if err == nil {
+		t.Errorf("Should not create duplicate edge")
+	}
+	if nerr, ok := err.(*DuplicateEdgeError); !ok {
+		t.Error("Unexpected error returned.", nerr.Error())
+	}
+
+	if graph.dag.GetSize() != expectedSize {
+		t.Errorf("Should have added edge to dag")
+	}
+}
+
+func TestGetVertex(t *testing.T) {
+	tearDown := setupTest(t)
+	defer tearDown(t)
+
+	specValue := 5
+
+	testSpec := reflect.TypeOf(specValue)
+	myService := &Service{SpecType: testSpec}
+
+	err := graph.AddVertex(myService)
+	if err != nil {
+		t.Errorf("Should add vertex! %s", err.Error())
+	}
+
+	actualService, err := graph.GetVertex(myService.Id)
+	if err != nil {
+		t.Errorf("Should be able to get vertex. %s", err.Error())
+	}
+	if actualService != myService {
+		t.Errorf("Created vertex should be the same as the one created. %s", err.Error())
+	}
+}

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
Some Transient dependencies that had N leaf descendants were correctly included in the instantiation order. Now, the order is correct, and will create the order the same way the order is created for static dependencies.